### PR TITLE
Configurer le titre du site depuis le repo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-postdeploy: python manage.py migrate
+postdeploy: python manage.py migrate && python manage.py loaddata init.json
 web: gunicorn config.wsgi --log-file -

--- a/config/settings.py
+++ b/config/settings.py
@@ -164,11 +164,11 @@ STATICFILES_FINDERS = [
 if os.getenv("S3_HOST"):
     AWS_S3_ACCESS_KEY_ID = os.getenv("S3_KEY_ID", "123")
     AWS_S3_SECRET_ACCESS_KEY = os.getenv("S3_KEY_SECRET", "secret")
-    AWS_S3_ENDPOINT_URL = f"{os.getenv('S3_PROTOCOL', 'https')}://{os.getenv('S3_HOST', 'set-var-env.com/')}"
+    AWS_S3_ENDPOINT_URL = os.getenv('S3_HOST')
     AWS_STORAGE_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "set-bucket-name")
     AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_BUCKET_REGION", "fr")
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-    MEDIA_URL = f"https://{AWS_S3_ENDPOINT_URL}/"  # noqa
+    MEDIA_URL = os.getenv('S3_HOST', 'set-var-env.com/')  # noqa
 else:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_URL = "medias/"

--- a/init.json
+++ b/init.json
@@ -1,0 +1,15 @@
+[{
+"model": "dsfr.dsfrconfig",
+"pk": 1,
+"fields": {
+"header_brand": "République française",
+"header_brand_html": "République<br />française",
+"footer_brand": "République française",
+"footer_brand_html": "République<br />française",
+"site_title": "Suite numérique",
+"site_tagline": "",
+"footer_description": "Exemple de description",
+"mourning": false,
+"accessibility_status": "NOT"
+}
+}]


### PR DESCRIPTION
# Objectif

Injecter automatiquement les titres au déploiement. 
- supprime une étape de cli après le déploiement
- les gens qui forkent peuvent changer le nom du site dans la foulée
- permet de versionner

C'est @Anna-Livia qui y a pensé ! 🧠 